### PR TITLE
Update to electron v19.0.9

### DIFF
--- a/build.jl
+++ b/build.jl
@@ -3,7 +3,7 @@ using Pkg.BinaryPlatforms
 using URIParser, FilePaths
 
 pkgname = "ElectronJS"
-version = v"19.0.4"
+version = v"19.0.9"
 build = 0
 
 build_path = joinpath(@__DIR__, "build")


### PR DESCRIPTION
In particular, this fixes a regression where always on top wasn't working on linux x11

https://github.com/electron/electron/releases/tag/v19.0.9